### PR TITLE
雑に Home の UI を再現

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -30,24 +30,24 @@ class _HomeState extends State<Home> {
               child: Center(
                 child: Text(
                   '現在のランキング',
-                  style: Theme.of(context).textTheme.titleLarge,
+                  style: Theme.of(context).textTheme.titleMedium,
                 ),
               ),
             ),
             Container(
               width: MediaQuery.of(context).size.width * 0.9,
               height: MediaQuery.of(context).size.height * 0.5,
-              color: Colors.tealAccent,
+              color: Colors.yellow,
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: [
                   Text(
                     '最近の記録',
-                    style: Theme.of(context).textTheme.titleLarge,
+                    style: Theme.of(context).textTheme.titleMedium,
                   ),
                   Text(
                     '変遷グラフ',
-                    style: Theme.of(context).textTheme.titleLarge,
+                    style: Theme.of(context).textTheme.titleMedium,
                   ),
                 ],
               ),

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'system_button.dart';
+
 class Home extends StatefulWidget {
   const Home({super.key});
 
@@ -8,40 +10,58 @@ class Home extends StatefulWidget {
 }
 
 class _HomeState extends State<Home> {
-  List<String> phrases = [
-    'You can go anywhere, be anything.',
-    'Stay hungry. Stay foolish.',
-    'Think different.',
-  ];
-
-  void shufflePhrases() {
-    setState(() {
-      phrases.shuffle();
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: const Text("The Natures"),
+        backgroundColor: Theme.of(context).colorScheme.background,
+        title: const Text("Flutter 検定"),
+        actions: const [SystemButton()],
       ),
       body: Center(
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.start,
           children: <Widget>[
-            Text(
-              phrases[0],
-              style: Theme.of(context).textTheme.titleLarge,
+            Container(
+              width: MediaQuery.of(context).size.width * 0.8,
+              height: MediaQuery.of(context).size.height * 0.1,
+              margin: const EdgeInsets.all(20.0),
+              color: Colors.red,
+              child: Center(
+                child: Text(
+                  '現在のランキング',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+              ),
+            ),
+            Container(
+              width: MediaQuery.of(context).size.width * 0.9,
+              height: MediaQuery.of(context).size.height * 0.5,
+              color: Colors.tealAccent,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  Text(
+                    '最近の記録',
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                  Text(
+                    '変遷グラフ',
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                ],
+              ),
             ),
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: shufflePhrases,
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () {},
         tooltip: 'Shuffle',
-        child: const Icon(Icons.sync),
+        icon: const Icon(Icons.fireplace),
+        splashColor: Theme.of(context).colorScheme.background,
+        label: const Text("検定に挑戦！"),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      title: 'The Natures',
+      title: 'Flutter 検定',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF40e0d0)),
         useMaterial3: true,

--- a/lib/system_button.dart
+++ b/lib/system_button.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+class SystemButton extends StatelessWidget {
+  const SystemButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: 5,
+        vertical: 10,
+      ),
+      child: IconButton(
+        icon: const Icon(Icons.menu),
+        onPressed: () {
+          showDialog<void>(
+            context: context,
+            builder: (context) => AlertDialog(
+              content: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text(
+                    "システムダイアログです",
+                    style: TextStyle(fontSize: 16),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.red,
+                    ),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                    },
+                    child: const Text(
+                      "閉じる",
+                      style: TextStyle(
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# 概要
Figma
https://www.figma.com/file/jVj8hvyVJnNLtl2rPBzCjt/Flutter-%E3%83%8F%E3%83%83%E3%82%AB%E3%82%BD%E3%83%B3?type=design&node-id=1%3A2&mode=design&t=pfHojrlimpoLTocA-1

# 細かな変更点
- アプリ名を「Flutter 検定」に変更
- AppBar 用のアクションボタンを作成
- Home ページのUIをざっくり作成

## スクリーンショット
| デザイン | スクリーンショット |
| :---: | :---: |
| <img width="402" alt="image" src="https://github.com/tanakahikari-pikka/flutter_certification/assets/31511218/42fc9ef3-1402-4b32-8ea8-699e777af8ef"> | <img width="309" alt="image" src="https://github.com/tanakahikari-pikka/flutter_certification/assets/31511218/86b10a11-b9a9-45fc-a2be-0003c86dc331"> |

# 影響範囲・懸念点
特になし

# おこなった動作確認
* [x] iOSシミュレータで確認